### PR TITLE
Add a missing gem: ruby_parser 

### DIFF
--- a/codesake-dawn.gemspec
+++ b/codesake-dawn.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'haml'
   gem.add_dependency 'parser'
   gem.add_dependency 'ptools'
+  gem.add_dependency 'ruby_parser'
 
   gem.add_dependency ('coveralls')
 


### PR DESCRIPTION
after gem install codesake_dawn you still have to install ruby_parser manually. this commit should fix that.
