### PR TITLE
Number of vulnerabilities as exit status code

### DIFF
--- a/bin/dawn
+++ b/bin/dawn
@@ -74,6 +74,7 @@ def help
   printf "\n   -o, --output [console, json. csv, html]\tthe output will be in the specified format"
   printf "\n   -V, --verbose\t\t\t\tthe output will be more verbose"
   printf "\n   -C, --count-only\t\t\t\tdawn will only count vulnerabilities (useful for scripts)"
+  printf "\n   -z, --exit-on-warn\t\t\t\tdawn will return number of found vulnerabilities as exit code"
   printf "\n   -v, --version\t\t\t\tshow version information"
   printf "\n   -h, --help\t\t\t\t\tshow this help\n"
 


### PR DESCRIPTION
Hi,

How do you feel about including an option for returning exit status other than 0 when vulnerabilities are found? (We implemented it so it returns the number of vulnerabilities.) We need this to include down in our deployment pipeline.

I named the option with respect to Brakeman's name, since we use is as additional security measurement. I can rename it, though, if you think it could be improved. 

Thanks.
