### PR TITLE
Fixes CVE-2013-0263 warning for rack 1.4.5

### DIFF
--- a/lib/codesake/dawn/kb/dependency_check.rb
+++ b/lib/codesake/dawn/kb/dependency_check.rb
@@ -6,7 +6,7 @@ module Codesake
 
         attr_accessor :dependencies
 
-        # This attribute replaces fixed_dependency in 20130521. 
+        # This attribute replaces fixed_dependency in 20130521.
         # There are cve checks like
         # http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2013-0175 that
         # addresses two different gems firing up the vulnerability. You can
@@ -17,23 +17,22 @@ module Codesake
 
 
         def vuln?
-          ret         = false
+          vulnerable  = false
           @mitigated  = false
           message     = ""
 
           @dependencies.each do |dep|
             # don't care about gem version when it mitigates a vulnerability... this can be risky, maybe I would reconsider in the future.
             @mitigated = true if dep[:name] == @aux_mitigation_gem[:name] unless @aux_mitigation_gem.nil?
-
             @safe_dependencies.each do |safe_dep|
               if @ruby_vulnerable_versions.empty?
-                if dep[:name] == safe_dep[:name] && is_vulnerable_version?(dep[:version], safe_dep[:version]) 
-                  ret = true
+                if dep[:name] == safe_dep[:name] && is_vulnerable_version?(dep[:version], safe_dep[:version])
+                  vulnerable = true
                   message = "Vulnerable #{dep[:name]} gem version found: #{dep[:version]}"
                 end
               else
                 if dep[:name] == safe_dep[:name] && is_vulnerable_version?(dep[:version], safe_dep[:version]) && is_ruby_vulnerable_version?
-                  ret = true
+                  vulnerable = true
                   message = "Vulnerable #{dep[:name]} gem version found: #{dep[:version]}"
                 end
               end
@@ -41,16 +40,16 @@ module Codesake
 
           end
 
-          if ret and @mitigated 
-            ret = false
+          if vulnerable and @mitigated
+            vulnerable = false
             message += "Vulnerability has been mitigated by gem #{@aux_mitigation_gem[:name]}. Don't remove it from your Gemfile"
           end
 
           self.evidences << message unless message.empty?
 
-          @status = ret
+          @status = vulnerable
 
-          ret
+          vulnerable
         end
       end
     end


### PR DESCRIPTION
But 1.4.5 actually fixes this vulnerability for versions <1.4.5. This
patch changes the the logic that determines if a given target version is
considered vulnerable to be hopefully correct.

Also:
- Renamed ret to vulnerable to clarify the code's intention.
- Removed some trailing spaces.
