### PR TITLE
Fix small sinatra bug

### DIFF
--- a/lib/codesake/dawn/sinatra.rb
+++ b/lib/codesake/dawn/sinatra.rb
@@ -19,7 +19,7 @@ module Codesake
         error! if self.appname == ""
         @views = detect_views
         @sinks = detect_sinks(self.appname) unless self.appname == ""
-        @reflected_xss = detect_reflected_xss unless self.appname == ""
+        @reflected_xss = detect_reflected_xss unless self.appname == "" || !@views
         @mount_point = (mp.nil?)? "" : mp
       end
 


### PR DESCRIPTION
Fix an issue with sinatra when no views folder is present.

Error:

```
$ dawn .
11:50:38 [*] dawn v1.2.0 is starting up
/Users/sadunne/.rvm/gems/ruby-2.0.0-p481@rest-server/gems/codesake-dawn-1.2.0/lib/codesake/dawn/sinatra.rb:37:in `detect_reflected_xss': undefined method `each' for nil:NilClass (NoMethodError)
    from /Users/sadunne/.rvm/gems/ruby-2.0.0-p481@rest-server/gems/codesake-dawn-1.2.0/lib/codesake/dawn/sinatra.rb:22:in `initialize'
    from /Users/sadunne/.rvm/gems/ruby-2.0.0-p481@rest-server/gems/codesake-dawn-1.2.0/lib/codesake/dawn/core.rb:107:in `new'
    from /Users/sadunne/.rvm/gems/ruby-2.0.0-p481@rest-server/gems/codesake-dawn-1.2.0/lib/codesake/dawn/core.rb:107:in `detect_mvc'
    from /Users/sadunne/.rvm/gems/ruby-2.0.0-p481@rest-server/gems/codesake-dawn-1.2.0/bin/dawn:167:in `<top (required)>'
    from /Users/sadunne/.rvm/gems/ruby-2.0.0-p481@rest-server/bin/dawn:23:in `load'
    from /Users/sadunne/.rvm/gems/ruby-2.0.0-p481@rest-server/bin/dawn:23:in `<main>'
    from /Users/sadunne/.rvm/gems/ruby-2.0.0-p481@rest-server/bin/ruby_executable_hooks:15:in `eval'
    from /Users/sadunne/.rvm/gems/ruby-2.0.0-p481@rest-server/bin/ruby_executable_hooks:15:in `<main>'
```
