### PR TITLE
Fixes nilClass bug for Sinatra apps without views

### DIFF
--- a/lib/codesake/dawn/sinatra.rb
+++ b/lib/codesake/dawn/sinatra.rb
@@ -117,6 +117,7 @@ module Codesake
 
       def detect_views
         return build_view_array(File.join(self.target, "views")) if File.exist?(File.join(self.target, "views"))
+        []
       end
 
       # e = Haml::Engine.new(File.read(template))


### PR DESCRIPTION
Resolves issue #96 by returning a default empty array if the preceding conditional fails.
