### PR TITLE
Fixes issue where debug mode was always enabled

### DIFF
--- a/lib/dawn/kb/cve_2015_7577.rb
+++ b/lib/dawn/kb/cve_2015_7577.rb
@@ -24,7 +24,7 @@ module Dawn
            })
           self.save_minor=true
           self.save_major=true
-          self.debug = true
+          # self.debug = true
           self.safe_dependencies = [{:name=>"activerecord", :version=>['3.1.9999','3.2.22.1', '4.1.14.1', '4.2.5.1', '5.0.0.beta1.1']}]
           self.not_affected = {:name=>"actionpack", :version=>['3.0.x']}
 


### PR DESCRIPTION
As reported in issue #209 a scan without debug mode enabled still
outputted debug statements. This was caused by a leftover `debug = true`
statement.

I've commented it out instead of removing it completely as this was done in other parts of the codebase as well.
