### PR TITLE
Fixes issue #223 - CVE-2016-2098 check not working.

### DIFF
--- a/lib/dawn/kb/version_check.rb
+++ b/lib/dawn/kb/version_check.rb
@@ -41,7 +41,24 @@ module Dawn
         return debug_me_and_return_false("detected version #{@detected} found as is in safe array")      if is_detected_in_safe?
         return debug_me_and_return_false("detected version #{@detected} is higher than all version marked safe")  if is_detected_highest?
 
-        @safe.sort.each do |s|
+        check_versions = nil
+        @safe.each do |safe_version|
+
+          sva = version_string_to_array(safe_version)
+          dva = version_string_to_array(@detected)
+
+          next unless is_same_version?(sva[:version], dva[:version], true)
+          next unless sva[:version].count == dva[:version].count || is_beta_check?(sva[:beta], dva[:beta]) || is_rc_check?(sva[:rc], dva[:rc]) || is_pre_check?(sva[:pre], dva[:pre])
+
+          check_versions = [safe_version]
+          break
+        end
+
+        debug_me "vuln?: limited check_versions: #{check_versions.inspect}"
+        check_versions ||= @safe
+        debug_me "vuln?: fallback check_versions: #{check_versions.inspect}"
+
+        check_versions.sort.each do |s|
           debug_me "vuln?: evaluating #{@detected} against save version: #{s}"
 
           @save_minor_fix   = save_minor_fix

--- a/spec/lib/kb/cve_2016_2098_spec.rb
+++ b/spec/lib/kb/cve_2016_2098_spec.rb
@@ -32,8 +32,12 @@ describe "The CVE-2016-2098 vulnerability" do
     @check.dependencies = [{:name=>"actionpack", :version=>"5.0.0.1"}]
 		expect(@check.vuln?).to   eq(false)
 	end
-	it "is not reported when a fixed release is detected" do
+  it "is not reported when a fixed release is detected" do
     @check.dependencies = [{:name=>"actionpack", :version=>"3.2.22.2"}]
+    expect(@check.vuln?).to   eq(false)
+  end
+	it "is not reported when a higher release is detected" do
+    @check.dependencies = [{:name=>"actionpack", :version=>"3.2.22.5"}]
 		expect(@check.vuln?).to   eq(false)
 	end
 	it "is not reported when a fixed release is detected" do


### PR DESCRIPTION
Hi there!

I created a fix for your issue #223 . It now limits the versions that have to be checked to the ones that are on the same minor level.

Happy Hacktoberfest 👍 